### PR TITLE
 - Updated wizard help text to refer to the actual button label

### DIFF
--- a/syncthing_gtk/wizard.py
+++ b/syncthing_gtk/wizard.py
@@ -195,7 +195,7 @@ class IntroPage(Page):
 			"\n\n" +
 			_("It looks like you never have used Syncthing.") + " " +
 			_("Initial configuration should be created.") +  " " +
-			_("Please, click <b>next</b> to create Syncthing configuration or <b>quit</b> to exit") +
+			_("Please click <b>Continue</b> to create a Syncthing configuration file or <b>Quit</b> to exit") +
 			"\n\n" +
 			(_("If you already had Syncthing daemon configured, please, "
 			  "exit this wizard and check your %s folder") % config_folder_link )


### PR DESCRIPTION
The Wizard help text did not match the buttons displayed:

![syncthing-gtk first run wizard_004](https://cloud.githubusercontent.com/assets/263427/5397013/e5f3db32-8156-11e4-8959-9ff4c92afc5d.png)

I changed the help text to reflect the button label  ("Continue") instead of ("Next")
