### PR TITLE
Chocolatey: Don't use the full installer

### DIFF
--- a/chocolatey_update.py
+++ b/chocolatey_update.py
@@ -34,8 +34,7 @@ version = lastRelease['name'].replace('v', '', )
 releaseNotes = lastRelease['body'].replace('\r', '').replace(':\n-', ':\n\n-')
 
 for asset in lastRelease['assets']:
-	print(asset['name'])
-	if re.match(r'.+win32(-full)?-installer.exe', asset['name']):
+	if re.match(r'.+win32-installer.exe', asset['name']):
 		# url = "https://cdn.rawgit.com/syncthing/syncthing-gtk/releases/download/"+lastRelease['name']+"/"+asset['name']
 		url = asset['browser_download_url']
 assert(url != ''), "ERR No fitting script found"

--- a/syncthing-gtk.nuspec
+++ b/syncthing-gtk.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>syncthing-gtk</id>
     <title>Syncthing GTK</title>
-    <version>0.5.2</version>
+    <version></version>
     <authors>syncthing,kozec</authors>
     <owners>GeoffreyFrogeye,kozec</owners>
     <summary>GUI and notification area icon for Syncthing</summary>
@@ -31,17 +31,7 @@ Additional features:
     <copyright></copyright>
     <licenseUrl>https://github.com/syncthing/syncthing-gtk/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>- Updated URL for Syncthing updater
-- Support for Syncthing >=0.10.9
-
-Cosmetics:
-
-- Automaticaly open topmost repo/device boxes when starting
-
-Fixes:
-
-- Anonymous usage reporting correctly stored, but incorrectly represented in UI
-- Bugged icon in Windows installer</releaseNotes>
+    <releaseNotes></releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName = 'syncthing-gtk'
 $installerType = 'EXE'
-$url = 'https://github.com/syncthing/syncthing-gtk/releases/download/v0.5.2/SyncthingGTK-0.5.2-win32-full-installer.exe'
+$url = ''
 $silentArgs = '/S'
 $validExitCodes = @(0)
 


### PR DESCRIPTION
Since there are two installers, the package selected would depend of
the order they were published. Used the light installer for Chocolatey
since it's better for the updates.
Also made .nuspec and installer .ps1 version independant.