### PR TITLE
a tiny fix to work with non-ascii folderpaths

### DIFF
--- a/syncthing_gtk/editordialog.py
+++ b/syncthing_gtk/editordialog.py
@@ -225,7 +225,7 @@ class EditorDialog(GObject.GObject):
 		if isinstance(w, Gtk.SpinButton):
 			w.get_adjustment().set_value(ints(self.get_value(key.lstrip("v"))))
 		elif isinstance(w, Gtk.Entry):
-			w.set_text(str(self.get_value(key.lstrip("v"))))
+			w.set_text(unicode(self.get_value(key.lstrip("v"))))
 		elif isinstance(w, Gtk.ComboBox):
 			val = self.get_value(key.lstrip("v"))
 			m = w.get_model()


### PR DESCRIPTION
in cases when the path contains non-ascii symbols this fixes a not-so-nice 'editor-all-greyed-out' bug for me.