### PR TITLE
a hack for non-ascii paths coming from watcher

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -983,6 +983,7 @@ class App(Gtk.Application, TimerManager):
 		relative path in that folder, or (None, None) if specified path
 		doesn't belongs anywhere
 		"""
+		path = path.decode("utf-8")
 		for folder_id in self.folders:
 			f = self.folders[folder_id]
 			relpath = os.path.relpath(path, f["norm_path"])


### PR DESCRIPTION
This hack fixes exceptions on inotify events when the paths contain non-ascii characters. At least for me. Also I don't know whether it's the right place to do the conversion.