### PR TITLE
Chocolatey: Use syncthing as a dependency

### DIFF
--- a/chocolatey_update.py
+++ b/chocolatey_update.py
@@ -48,8 +48,12 @@ nuspecFile = open("syncthing-gtk.nuspec", "r", encoding="utf8")
 nuspecString = nuspecFile.read()
 nuspecFile.close()
 
+from syncthing_gtk import app
+minStVersion = app.MIN_ST_VERSION
+
 nuspecString = re.sub(r'<version>.*</version>', '<version>'+version+'</version>', nuspecString)
 nuspecString = re.sub(r'<releaseNotes>[\w\W]*</releaseNotes>', '<releaseNotes>'+releaseNotes+'</releaseNotes>', nuspecString)
+nuspecString = re.sub(r'<dependency id="syncthing" version=".*"/>', '<dependency id="syncthing" version="'+minStVersion+'"/>', nuspecString)
 
 nuspecFile = open("syncthing-gtk.nuspec", "w", encoding="utf8")
 print(nuspecString, file=nuspecFile, end="")

--- a/syncthing-gtk.nuspec
+++ b/syncthing-gtk.nuspec
@@ -31,6 +31,11 @@ Additional features:
     <copyright></copyright>
     <licenseUrl>https://github.com/syncthing/syncthing-gtk/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+    	<group>
+    		<dependency id="syncthing" version=""/>
+    	</group>
+    </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
   <files>


### PR DESCRIPTION
As @Ferk suggested by mail, we can use [the syncthing chocolatey package](https://chocolatey.org/packages/syncthing) as a dependency of the [the syncthing-gtk chocolatey package](https://chocolatey.org/packages/syncthing-gtk). That's cool, we wanted a `syncthing`package since #28.

So, here is a simple commit that add `syncthing` as a dependency to our chocolatey package, and update the minimum required version from [app.py](https://github.com/syncthing/syncthing-gtk/blob/master/syncthing_gtk/app.py) when updating it.

**However**, the actual syncthing package is stuck on 0.10, with 0.11 (which is the version required by syncthing-gtk) awaiting moderation. Even if fixed, this issue may happen again later in time, so I think it would be wise to wait for `syncthing` becoming a trusted package.

Do **not** merge until the following is fulfilled :

- [ ] Wait until [the syncthing chocolatey package](https://chocolatey.org/packages/syncthing) get trusted
- [ ] Testing with the above condition