### PR TITLE
Add prefix paths for Exherbo's filesystem layout

### DIFF
--- a/syncthing_gtk/uisettingsdialog.py
+++ b/syncthing_gtk/uisettingsdialog.py
@@ -239,6 +239,8 @@ def library_exists(name):
 		"/usr/lib64",	# Fedora
 		"/usr/lib",
 		"/usr/local/lib/",
+		"/usr/x86_64-pc-linux-gnu/lib/",
+		"/usr/i686-pc-linux-gnu/lib/",
 		"/usr/lib/x86_64-linux-gnu/",
 		"/usr/lib/i386-linux-gnu/",
 	]


### PR DESCRIPTION
[Exherbo](http://exherbo.org/) uses a [filesystem layout](https://exherbo.org/docs/multiarch.txt) which separates libraries and binaries based on what CHOST they were compiled for. `/usr/lib`, on Exherbo, is just a symlink to whatever the host machine's correct lib folder would be, which would break if running `i686-pc-linux-gnu` compiled things on a `x86_64-pc-linux-gnu` host; `syncthing-gtk` would start looking for x86_64-pc-linux-gnu's Nautilus library, and wouldn't find it correctly if it were only compiled for i686-pc-linux-gnu.