### PR TITLE
daemonprocess: Use more compatible syntax for `nice`

### DIFF
--- a/syncthing_gtk/daemonprocess.py
+++ b/syncthing_gtk/daemonprocess.py
@@ -72,7 +72,7 @@ class DaemonProcess(GObject.GObject):
 					self._proc = Gio.Subprocess.new(self.commandline, flags)
 				else:
 					# I just really do hope that there is no distro w/out nice command
-					self._proc = Gio.Subprocess.new([ "nice", "-n %s" % self.priority ] + self.commandline, flags)
+					self._proc = Gio.Subprocess.new([ "nice", "-n", "%s" % self.priority ] + self.commandline, flags)
 				self._proc.wait_check_async(None, self._cb_finished)
 				self._stdout = self._proc.get_stdout_pipe()
 			else:
@@ -81,7 +81,7 @@ class DaemonProcess(GObject.GObject):
 					self._proc = Popen(self.commandline, stdout=PIPE)
 				else:
 					# still hoping
-					self._proc = Popen([ "nice", "-n %s" % self.priority ], stdout=PIPE)
+					self._proc = Popen([ "nice", "-n", "%s" % self.priority ], stdout=PIPE)
 				self._stdout = Gio.UnixInputStream.new(self._proc.stdout.fileno(), False)
 				self._check = GLib.timeout_add_seconds(1, self._cb_check_alive)
 		except Exception, e:

--- a/syncthing_gtk/daemonprocess.py
+++ b/syncthing_gtk/daemonprocess.py
@@ -72,7 +72,7 @@ class DaemonProcess(GObject.GObject):
 					self._proc = Gio.Subprocess.new(self.commandline, flags)
 				else:
 					# I just really do hope that there is no distro w/out nice command
-					self._proc = Gio.Subprocess.new([ "nice", "-%s" % self.priority ] + self.commandline, flags)
+					self._proc = Gio.Subprocess.new([ "nice", "-n %s" % self.priority ] + self.commandline, flags)
 				self._proc.wait_check_async(None, self._cb_finished)
 				self._stdout = self._proc.get_stdout_pipe()
 			else:
@@ -81,7 +81,7 @@ class DaemonProcess(GObject.GObject):
 					self._proc = Popen(self.commandline, stdout=PIPE)
 				else:
 					# still hoping
-					self._proc = Popen([ "nice", "-%s" % self.priority ], stdout=PIPE)
+					self._proc = Popen([ "nice", "-n %s" % self.priority ], stdout=PIPE)
 				self._stdout = Gio.UnixInputStream.new(self._proc.stdout.fileno(), False)
 				self._check = GLib.timeout_add_seconds(1, self._cb_check_alive)
 		except Exception, e:


### PR DESCRIPTION
On systems with non-GNU coreutils, `nice` usually expects to have `-n %s` passed to it, as the way
to specify the priority desired, rather than `-%s` which doesn't work on some implementations.