### PR TITLE
Find Syncthing config correctly on XP

### DIFF
--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -338,7 +338,7 @@ def get_config_dir():
 	"""
 	if is_portable():
 		return os.environ["XDG_CONFIG_HOME"]
-	if IS_WINDOWS:
+	if IS_WINDOWS and not IS_XP:
 		try:
 			import windows
 			return windows.get_unicode_home()


### PR DESCRIPTION
This call on XP expands to `Local Settings/Application Data` but Syncthing is storing config in just `Application Data`.

Closes #238