### PR TITLE
syncthing-gtk.desktop: add missing semicolon

### DIFF
--- a/syncthing-gtk.desktop
+++ b/syncthing-gtk.desktop
@@ -5,4 +5,4 @@ Comment=GUI for Syncthing
 Exec=/usr/bin/syncthing-gtk
 Type=Application
 Icon=syncthing-gtk
-Categories=Network
+Categories=Network;


### PR DESCRIPTION
introduce a missing semicolon from the "Categories" line in the desktop file. It is needed for freedesktop.org specification compliance

it fixes this desktop-file-validate error:
/usr/share/applications/syncthing-gtk.desktop: error: value "Network" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character