### PR TITLE
absolute path to explorer.exe for Windows

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1763,8 +1763,9 @@ class App(Gtk.Application, TimerManager):
 		path = os.path.expanduser(box["path"])
 		if IS_WINDOWS:
 			# Don't attempt anything, use Windows Explorer on Windows
+			windows = os.environ("SystemRoot")
 			path = path.replace("/", "\\")
-			os.system('explorer "%s"' % (path,))
+			os.system('%s\\explorer.exe "%s"' % (windows, path))
 		else:
 			# Try to use any of following, known commands to
 			# display directory contents


### PR DESCRIPTION
Due to changes in the PATH environment variable in commit 38e42c566225494e7ccd9d5c4a2044540c2ee2c3 explorer.exe can not be found.  Now using SystemRoot environment variable to create absolute path to explorer.exe