### PR TITLE
simpler fix for Windows Explorer

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1775,9 +1775,8 @@ class App(Gtk.Application, TimerManager):
 		path = os.path.expanduser(box["path"])
 		if IS_WINDOWS:
 			# Don't attempt anything, use Windows Explorer on Windows
-			windows = os.environ("SystemRoot")
 			path = path.replace("/", "\\")
-			os.system('%s\\explorer.exe "%s"' % (windows, path))
+			os.startfile(path, 'explore')
 		else:
 			# Try to use any of following, known commands to
 			# display directory contents


### PR DESCRIPTION
Now using [os.startfile](https://docs.python.org/3.5/library/os.html#os.startfile) to launch Windows Explorer directly.  No need to mess with getting absolute path to explorer.exe (which I botched in my previous pull request).

