### PR TITLE
Include Folder Label in notifications

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1353,6 +1353,7 @@ class App(Gtk.Application, TimerManager):
 			box.add_hidden_value("can_override", False)
 			box.add_hidden_value("devices", shared)
 			box.add_hidden_value("norm_path", os.path.abspath(os.path.expanduser(path)))
+			box.add_hidden_value("label", label)
 			# Setup display & signal
 			box.set_status("Unknown")
 			if not self.dark_color is None:

--- a/syncthing_gtk/notifications.py
+++ b/syncthing_gtk/notifications.py
@@ -164,7 +164,11 @@ if HAS_DESKTOP_NOTIFY:
 		def cb_syncthing_folder_finished(self, daemon, folder_id):
 			if folder_id in self.syncing:
 				self.syncing.remove(folder_id)
-				self.info(_("Synchronization of folder '%s' is completed.") % (folder_id,))
+                                folder_label = self.app.folders[folder_id]["label"]
+                                markup = _("Synchronization of folder '%s' is completed.") % {
+                                        (folder_label or folder_id)
+                                        }
+                                self.info(markup)
 		
 		def display(self):
 			if len(self.updated) == 1 and len(self.deleted) == 0:

--- a/syncthing_gtk/notifications.py
+++ b/syncthing_gtk/notifications.py
@@ -121,7 +121,10 @@ if HAS_DESKTOP_NOTIFY:
 		def cb_syncthing_folder_rejected(self, daemon, nid, rid, label):
 			if nid in self.app.devices:
 				device = self.app.devices[nid].get_title()
-				markup = _('Unexpected folder ID sent from device "%s".') % ("<b>%s</b>" % device,)
+				markup = _('Unexpected folder "%(folder)s" sent from device "%(device)s".') % {
+                                        'device' : "<b>%s</b>" % device,
+                                        'folder' : "<b>%s</b>" % (label or rid)
+                                }
 				self.info(markup)
 		
 		def cb_syncthing_device_rejected(self, daemon, nid, name, address):


### PR DESCRIPTION
Two more instances where the Folder Label should be displayed if set. Note that the second commit requires translation updates.

I'm not quite sure how to test the sync complete callback, I can usually only trigger `cb_syncthing_item_updated`, so please test this again before merging!