### PR TITLE
Chocolatey: Hash support

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,8 @@
 $packageName = 'syncthing-gtk'
 $installerType = 'EXE'
 $url = ''
+$checksum = ''
+$checksumType = 'sha256'
 $silentArgs = '/S'
 $validExitCodes = @(0)
 


### PR DESCRIPTION
**DO NO NOT MERGE YET** It's actually failing the automated chocolatey tests.

Which means the installer file is downloaded and its sha256sum is included in the package.

This is not (yet) mandatory since the download is done through HTTPS but it's a plus.

Also the line endings changed to Unix-style (because I'm commiting from Linux since I've broke my git config on Windows), I don't really know how to prevent that and if it is to be prevented.
