### PR TITLE
Fix broken link to "syncthing" in first line of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Syncthing-GTK
 =============
 
-GTK3 &amp; Python based GUI and notification area icon for [Syncthing](syncthing)
+GTK3 &amp; Python based GUI and notification area icon for [Syncthing](https://github.com/syncthing/syncthing)
 
 [![screenshot1](http://i.imgur.com/N36wmBM.png)](http://i.imgur.com/eX250tQ.png) [![screenshot2](http://i.imgur.com/43mmnC7.png)](http://i.imgur.com/RTRgRdC.png) [![screenshot3](http://i.imgur.com/KDBYekd.png)](http://i.imgur.com/OZ4xEeH.jpg)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Syncthing-GTK
 =============
 
-GTK3 &amp; Python based GUI and notification area icon for [Syncthing][syncthing]
+GTK3 &amp; Python based GUI and notification area icon for [Syncthing](syncthing)
 
 [![screenshot1](http://i.imgur.com/N36wmBM.png)](http://i.imgur.com/eX250tQ.png) [![screenshot2](http://i.imgur.com/43mmnC7.png)](http://i.imgur.com/RTRgRdC.png) [![screenshot3](http://i.imgur.com/KDBYekd.png)](http://i.imgur.com/OZ4xEeH.jpg)
 


### PR DESCRIPTION
This fixes #345.

Requesting merge against `master` since this isn't a fix to any code or functionality, but just a github-visible README file. I am happy to move it into a branch if that's preferred.

I couldn't find contributing guidelines in the syncthing-gtk repo, but am guilty of not looking too hard; apologies if I broke any rules.