### PR TITLE
Terminate if main window is closed and status indicator is not showing

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1673,8 +1673,11 @@ class App(Gtk.Application, TimerManager):
 		AboutDialog(self, self.gladepath).show(self["window"])
 	
 	def cb_delete_event(self, *e):
-		# Hide main window
-		self.hide()
+		# Hide main window if the status icon is visible, otherwise quit
+		if self.statusicon.get_active():
+			self.hide()
+		else:
+			self.quit()
 		return True
 	
 	def cb_realized(self, widget, *a):

--- a/syncthing_gtk/statusicon.py
+++ b/syncthing_gtk/statusicon.py
@@ -460,11 +460,18 @@ class StatusIconAppIndicator(StatusIconDBus):
 		self._tray = appindicator.Indicator.new("syncthing-gtk", self._get_icon(), category)
 		self._tray.set_menu(self._get_popupmenu())
 		self._tray.set_title(self.TRAY_TITLE)
+		
+		self._tray.connect("connection-changed", self._on_connection_changed)
+		self._on_connection_changed()
 	
 	def _set_visible(self, active):
 		StatusIcon._set_visible(self, active)
 		
 		self._tray.set_status(self._status_active if active else self._status_passive)
+	
+	def _on_connection_changed(self, *args):
+		is_connected = self._tray.get_property("connected")
+		self.set_property("active", is_connected)
 	
 	def set(self, icon=None, text=None):
 		StatusIcon.set(self, icon, text)


### PR DESCRIPTION
As mentioned in #369, when syncthing-gtk cannot show its status indicator and the main window is closed, its process does not terminate.

I looked over your code and found that this situation is not specific to Gnome or Wayland. Syncthing-gtk already can detect whether the status indicator is showing (the `active` property on `StatusIcon`), and it already has a fallback for when the platform doesn't seem to support status indicators at all (`StatusIconDummy`).

I see two problems here:

1. `StatusIconAppIndicator` doesn't update its `active` property.

2. Closing the main window doesn't terminate syncthing-gtk, even if the status indicator is not active.

This PR contains two commits, one for each of the aforementioned problems (f16fa9f and 5d97439, respectively). This directly fixes #369.