### PR TITLE
syncthing-gtk.desktop: Don't assume that syncthing-gtk is in /usr/bin.

### DIFF
--- a/syncthing-gtk.desktop
+++ b/syncthing-gtk.desktop
@@ -2,7 +2,7 @@
 Name=Syncthing GTK
 GenericName=Syncthing GTK
 Comment=GUI for Syncthing
-Exec=/usr/bin/syncthing-gtk
+Exec=syncthing-gtk
 Type=Application
 Icon=syncthing-gtk
 Categories=Network;


### PR DESCRIPTION
This trivial change partially addresses #371, though it's not a complete solution.