### PR TITLE
Fixed addresses not allowing dynamic alongside other options

### DIFF
--- a/syncthing_gtk/deviceeditor.py
+++ b/syncthing_gtk/deviceeditor.py
@@ -122,7 +122,7 @@ class DeviceEditorDialog(EditorDialog):
 				self.set_value("addresses", "dynamic")
 			else:
 				addresses = [
-					x.strip() if "://" in x else "tcp://%s" % (x.strip(),)
+					x.strip() if "://" in x or x == "dynamic" else "tcp://%s" % (x.strip(),)
 					for x in addresses.split(",") ]
 				self.set_value("addresses", ",".join(addresses))
 		elif key == "vfolders":

--- a/syncthing_gtk/deviceeditor.py
+++ b/syncthing_gtk/deviceeditor.py
@@ -116,15 +116,10 @@ class DeviceEditorDialog(EditorDialog):
 	#@Overrides
 	def store_value(self, key, w):
 		if key == "vaddresses":
-			addresses = w.get_text().strip()
-			if addresses == "dynamic":
-				# Special case
-				self.set_value("addresses", "dynamic")
-			else:
-				addresses = [
-					x.strip() if "://" in x or x.strip() == "dynamic" else "tcp://%s" % (x.strip(),)
-					for x in addresses.split(",") ]
-				self.set_value("addresses", ",".join(addresses))
+			addresses = [
+				x.strip() if "://" in x or x.strip() == "dynamic" else "tcp://%s" % (x.strip(),)
+				for x in w.get_text().split(",") ]
+			self.set_value("addresses", ",".join(addresses))
 		elif key == "vfolders":
 			# Generate dict of { folder_id : bool } where bool is True if
 			# folder should be shared with this device

--- a/syncthing_gtk/deviceeditor.py
+++ b/syncthing_gtk/deviceeditor.py
@@ -122,7 +122,7 @@ class DeviceEditorDialog(EditorDialog):
 				self.set_value("addresses", "dynamic")
 			else:
 				addresses = [
-					x.strip() if "://" in x or x == "dynamic" else "tcp://%s" % (x.strip(),)
+					x.strip() if "://" in x or x.strip() == "dynamic" else "tcp://%s" % (x.strip(),)
 					for x in addresses.split(",") ]
 				self.set_value("addresses", ",".join(addresses))
 		elif key == "vfolders":


### PR DESCRIPTION
Previously, if you were to type, say, `tcp://1.2.3.4:22000,dynamic`, it would be saved as `tcp://1.2.3.4:22000,tcp://dynamic` which would break the behavior of dynamic.

This fixes the behavior by adding a check specifically for the `dynamic` value to ensure that it does not have `tcp://` prepended.

This improves upon the solution for issue #300 