### PR TITLE
chocolatey_update.py: make it work with latest release schema

### DIFF
--- a/chocolatey_update.py
+++ b/chocolatey_update.py
@@ -34,7 +34,7 @@ version = lastRelease['name'].replace('v', '', )
 releaseNotes = lastRelease['body'].replace('\r', '').replace(':\n-', ':\n\n-')
 
 for asset in lastRelease['assets']:
-	if re.match(r'.+win32-installer.exe', asset['name']):
+	if re.match(r'.+win32-full-installer.exe', asset['name']):
 		# url = "https://cdn.rawgit.com/syncthing/syncthing-gtk/releases/download/"+lastRelease['name']+"/"+asset['name']
 		url = asset['browser_download_url']
 assert(url != ''), "ERR No fitting script found"


### PR DESCRIPTION
I have confirmed that this is usable with latest version.