### PR TITLE
Use newer notation

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -363,7 +363,7 @@ class App(Gtk.Application, TimerManager):
 				self.daemon = Daemon(os.path.join(self.home_dir_override, "config.xml"))
 			else:
 				self.daemon = Daemon()
-		except InvalidConfigurationException, e:
+		except InvalidConfigurationException as e:
 			# Syncthing is not configured, most likely never launched.
 			# Run wizard.
 			if IS_XP:
@@ -374,7 +374,7 @@ class App(Gtk.Application, TimerManager):
 			self.hide()
 			self.show_wizard()
 			return False
-		except TLSErrorException, e:
+		except TLSErrorException as e:
 			# This is pretty-much fatal. Display error message and bail out.
 			self.cb_syncthing_con_error(self.daemon, Daemon.UNKNOWN, str(e), e)
 			return False
@@ -622,20 +622,20 @@ class App(Gtk.Application, TimerManager):
 		# Move old from way
 		try:
 			shutil.move(bin, old_bin)
-		except Exception, e:
+		except Exception as e:
 			log.warning("Failed to upgrade daemon binary: Failed to rename old binary")
 			log.warning(e)
 			return
 		# Place new
 		try:
 			shutil.move(new_bin, bin)
-		except Exception, e:
+		except Exception as e:
 			log.warning("Failed to upgrade daemon binary: Failed to rename new binary")
 			log.warning(e)
 			# Return old back to place
 			try:
 				shutil.move(old_bin, bin)
-			except Exception, e:
+			except Exception as e:
 				# This really shouldn't happen, in more than one sense
 				log.error("Failed to upgrade daemon binary: Failed to rename backup")
 				log.exception(e)
@@ -643,7 +643,7 @@ class App(Gtk.Application, TimerManager):
 		# Remove old
 		try:
 			os.unlink(old_bin)
-		except Exception, e:
+		except Exception as e:
 			# Not exactly fatal
 			log.warning("Failed to remove backup binary durring backup")
 			log.warning(e)

--- a/syncthing_gtk/configuration.py
+++ b/syncthing_gtk/configuration.py
@@ -61,7 +61,7 @@ class _Configuration(object):
 	def __init__(self):
 		try:
 			self.load()
-		except Exception, e:
+		except Exception as e:
 			log.warning("Failed to load configuration; Creating new one.")
 			log.warning("Reason: %s", (e,))
 			self.create()
@@ -80,7 +80,7 @@ class _Configuration(object):
 		if not os.path.exists(self.get_config_dir()):
 			try:
 				os.makedirs(self.get_config_dir())
-			except Exception, e:
+			except Exception as e:
 				log.error("Cannot create configuration directory")
 				log.exception(e)
 				sys.exit(1)
@@ -139,7 +139,7 @@ class _Configuration(object):
 					elif tp == bool and type(self.values[key]) in (int, long):
 						# Convert bools
 						self.values[key] = bool(self.values[key])
-				except Exception, e:
+				except Exception as e:
 					log.warning("Failed to parse configuration value '%s'. Using default.", key)
 					log.warning(e)
 					# Value will be re-created by check_values method

--- a/syncthing_gtk/daemon.py
+++ b/syncthing_gtk/daemon.py
@@ -332,17 +332,17 @@ class Daemon(GObject.GObject, TimerManager):
 		try:
 			log.debug("Reading syncthing config %s", self._configxml)
 			config = file(self._configxml, "r").read()
-		except Exception, e:
+		except Exception as e:
 			raise InvalidConfigurationException("Failed to read daemon configuration: %s" % e)
 		try:
 			xml = minidom.parseString(config)
-		except Exception, e:
+		except Exception as e:
 			raise InvalidConfigurationException("Failed to parse daemon configuration: %s" % e)
 		tls = "false"
 		try:
 			tls = xml.getElementsByTagName("configuration")[0] \
 				.getElementsByTagName("gui")[0].getAttribute("tls")
-		except Exception, e:
+		except Exception as e:
 			pass
 		self._tls = False
 		self._cert = None
@@ -351,7 +351,7 @@ class Daemon(GObject.GObject, TimerManager):
 			try:
 				self._cert = Gio.TlsCertificate.new_from_file(
 					os.path.join(get_config_dir(), "syncthing", "https-cert.pem"))
-			except Exception, e:
+			except Exception as e:
 				log.exception(e)
 				raise TLSErrorException("Failed to load daemon certificate")
 		try:
@@ -363,7 +363,7 @@ class Daemon(GObject.GObject, TimerManager):
 				addr, port = self._address.split(":", 1)
 				self._address = "127.0.0.1:%s" % (port,)
 				log.debug("WebUI listens on 0.0.0.0, connecting to 127.0.0.1 instead")
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			raise InvalidConfigurationException("Required configuration node not found in daemon config file")
 		try:
@@ -371,7 +371,7 @@ class Daemon(GObject.GObject, TimerManager):
 							.getElementsByTagName("gui")[0] \
 							.getElementsByTagName("apikey")[0] \
 							.firstChild.nodeValue
-		except Exception, e:
+		except Exception as e:
 			# API key can be none
 			pass
 	
@@ -1051,7 +1051,7 @@ class RESTRequest(Gio.SocketClient):
 			self._connection = self.connect_to_service_finish(results)
 			if self._connection == None:
 				raise Exception("Unknown error")
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			if hasattr(e, "domain") and e.domain == "g-tls-error-quark":
 				e = TLSUnsupportedException(e.message)
@@ -1080,7 +1080,7 @@ class RESTRequest(Gio.SocketClient):
 		get_str = self._format_request()
 		try:
 			self._connection.get_output_stream().write_all(get_str, None)
-		except Exception, e:
+		except Exception as e:
 			self._error(e)
 			return
 		self._connection.get_input_stream().read_bytes_async(102400, 1, None, self._response)
@@ -1115,7 +1115,7 @@ class RESTRequest(Gio.SocketClient):
 			response = stream.read_bytes_finish(results)
 			if response == None:
 				raise Exception("No data recieved")
-		except Exception, e:
+		except Exception as e:
 			print e
 			self._connection.close(None)
 			self._error(e)
@@ -1174,7 +1174,7 @@ class RESTRequest(Gio.SocketClient):
 			elif code != 200:
 				self._error(HTTPCode(code, response, buffer, headers))
 				return None, None
-		except Exception, e:
+		except Exception as e:
 			# That probably wasn't HTTP
 			import traceback
 			traceback.print_exc()
@@ -1302,7 +1302,7 @@ class EventPollLoop(RESTRequest):
 			response = stream.read_bytes_finish(results)
 			if response == None:
 				raise Exception("No data recieved")
-		except Exception, e:
+		except Exception as e:
 			return self._error(e)
 		if self._epoch != self._parent._epoch:
 			self._connection.close(None)
@@ -1326,7 +1326,7 @@ class EventPollLoop(RESTRequest):
 			response = stream.read_bytes_finish(results)
 			if response == None:
 				raise Exception("nothing")
-		except Exception, e:
+		except Exception as e:
 			return self._error(e)
 		if self._epoch != self._parent._epoch:
 			self._connection.close(None)
@@ -1351,7 +1351,7 @@ class EventPollLoop(RESTRequest):
 			]).encode("utf-8")
 		try:
 			self._connection.get_output_stream().write_all(get_str, None)
-		except Exception, e:
+		except Exception as e:
 			print e
 			self._connection.close(None)
 			return self.start()

--- a/syncthing_gtk/daemonprocess.py
+++ b/syncthing_gtk/daemonprocess.py
@@ -84,7 +84,7 @@ class DaemonProcess(GObject.GObject):
 					self._proc = Popen([ "nice", "-n", "%s" % self.priority ], stdout=PIPE)
 				self._stdout = Gio.UnixInputStream.new(self._proc.stdout.fileno(), False)
 				self._check = GLib.timeout_add_seconds(1, self._cb_check_alive)
-		except Exception, e:
+		except Exception as e:
 			# Startup failed
 			self.emit("failed", e)
 			return
@@ -96,7 +96,7 @@ class DaemonProcess(GObject.GObject):
 		""" Handler for read_bytes_async """
 		try:
 			response = pipe.read_bytes_finish(results)
-		except Exception, e:
+		except Exception as e:
 			if not self._cancel.is_cancelled():
 				log.exception(e)
 				GLib.idle_add(pipe.read_bytes_async, 256, 1, None, self._cb_read)

--- a/syncthing_gtk/deviceeditor.py
+++ b/syncthing_gtk/deviceeditor.py
@@ -74,7 +74,7 @@ class DeviceEditorDialog(EditorDialog):
 					self.set_value("deviceID", self.id)
 			else:
 				self.values = [ x for x in self.config["devices"] if x["deviceID"] == self.id ][0]
-		except KeyError, e:
+		except KeyError as e:
 			# ID not found in configuration. This is practicaly impossible,
 			# so it's handled only by self-closing dialog.
 			log.exception(e)

--- a/syncthing_gtk/foldereditor.py
+++ b/syncthing_gtk/foldereditor.py
@@ -153,7 +153,7 @@ class FolderEditorDialog(EditorDialog):
 				}
 				self["vpath"].set_sensitive(False)
 				self["btBrowse"].set_sensitive(False)
-		except KeyError, e:
+		except KeyError as e:
 			# ID not found in configuration. This is practicaly impossible,
 			# so it's handled only by self-closing dialog.
 			log.exception(e)

--- a/syncthing_gtk/foldereditor.py
+++ b/syncthing_gtk/foldereditor.py
@@ -21,7 +21,7 @@ VALUES = [ "vlabel", "vid", "vpath", "vreadOnly", "vignorePerms", "vdevices",
 	"vversionsPath", "vfsWatcherEnabled", "vcleanoutDays", "vcommand", "vorder",
 	"vminDiskFreePct"
 	]
-VERSIONING_TYPES = set(['simple', 'staggered', 'trashcan', 'external'])
+VERSIONING_TYPES = {'simple', 'staggered', 'trashcan', 'external'}
 
 class FolderEditorDialog(EditorDialog):
 	def __init__(self, app, is_new, id=None, path=None):

--- a/syncthing_gtk/iddialog.py
+++ b/syncthing_gtk/iddialog.py
@@ -83,12 +83,12 @@ class IDDialog(object):
 				tf.close()
 				self["vQR"].set_from_file(tf.name)
 				os.unlink(tf.name)
-		except GLib.Error, e:
+		except GLib.Error as e:
 			if e.code in [14, 15]:
 				# Unauthorized. Grab CSRF token from daemon and try again
 				log.warning("Failed to load image using glib. Retrying with urllib2.")
 				self.load_data_urllib()
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			return
 		finally:

--- a/syncthing_gtk/nautilusplugin.py
+++ b/syncthing_gtk/nautilusplugin.py
@@ -39,7 +39,7 @@ class NautiluslikeExtension(GObject.GObject):
 		self.ready = False
 		try:
 			self.daemon = Daemon()
-		except Exception, e:
+		except Exception as e:
 			# Syncthing is not configured, most likely never launched.
 			log.error("%s", e)
 			log.error("Failed to read Syncthing configuration.")

--- a/syncthing_gtk/notifications.py
+++ b/syncthing_gtk/notifications.py
@@ -47,7 +47,7 @@ if HAS_DESKTOP_NOTIFY:
 			try:
 				self.icon = Gtk.IconTheme.get_default().load_icon("syncthing-gtk", 64, Gtk.IconLookupFlags.FORCE_SIZE)
 				self.error_icon = Gtk.IconTheme.get_default().load_icon("syncthing-gtk-error", 64, Gtk.IconLookupFlags.FORCE_SIZE)
-			except Exception, e:
+			except Exception as e:
 				log.error("Failed to load icon: %s", e)
 			# Make deep connection with daemon
 			self.signals = [

--- a/syncthing_gtk/stdownloader.py
+++ b/syncthing_gtk/stdownloader.py
@@ -75,7 +75,7 @@ class StDownloader(GObject.GObject):
 		GObject.GObject.__init__(self)
 		self.target = target
 		self.platform = platform
-		# Latest Syncthing version known to be compatibile with
+		# Latest Syncthing version known to be compatible with
 		# Syncthing-GTK. This is just hardcoded minimal version,
 		# actual value will be determined later
 		self.latest_compat = "v0.11.0"
@@ -160,13 +160,13 @@ class StDownloader(GObject.GObject):
 						if tag.startswith("Syncthing_"):
 							# ST-GTK version has ST version attached.
 							# Check if this is newer than last known
-							# compatibile version
+							# compatible version
 							st_ver = tag.split("_")[-1]
 							if compare_version(st_ver, self.latest_compat):
-								log.verbose("STDownloader: Got newer compatibile Syncthing version %s", st_ver)
+								log.verbose("STDownloader: Got newer compatible Syncthing version %s", st_ver)
 								self.latest_compat = st_ver
 
-			log.verbose("STDownloader: Latest compatibile Syncthing version: %s", self.latest_compat)
+			log.verbose("STDownloader: Latest compatible Syncthing version: %s", self.latest_compat)
 
 		except Exception as e:
 			log.exception(e)
@@ -174,8 +174,8 @@ class StDownloader(GObject.GObject):
 				_("Failed to determine latest Syncthing version."))
 			return
 
-		# After latest compatibile ST version is determined, determine
-		# latest actually existing version. This should be usualy same,
+		# After latest compatible ST version is determined, determine
+		# latest actually existing version. This should be usually same,
 		# but checking is better than downloading non-existant file.
 		uri = StDownloader.ST_URL
 		f = Gio.File.new_for_uri(uri)
@@ -188,7 +188,7 @@ class StDownloader(GObject.GObject):
 		try:
 			success, data, etag = f.load_contents_finish(result)
 			if not success: raise Exception("Gio download failed")
-			# Go over all available versions until compatibile one
+			# Go over all available versions until compatible one
 			# is found
 			data = json.loads(data)
 			for release in data:
@@ -196,8 +196,8 @@ class StDownloader(GObject.GObject):
 				if latest_ver is None:
 					latest_ver = version
 				if compare_version(self.latest_compat, version) and (self.forced or compare_version(version, MIN_ST_VERSION)):
-					# Compatibile
-					log.verbose("STDownloader: Found compatibile Syncthing version: %s", version)
+					# compatible
+					log.verbose("STDownloader: Found compatible Syncthing version: %s", version)
 					self.version = version
 					for asset in release["assets"]:
 						if self.platform in asset["name"]:
@@ -233,7 +233,7 @@ class StDownloader(GObject.GObject):
 				prefix="syncthing-package.", suffix=suffix, delete=False)
 		except Exception as e:
 			log.exception(e)
-			self.emit("error", e, _("Failed to create temporaly file."))
+			self.emit("error", e, _("Failed to create temporary file."))
 			return
 		f = Gio.File.new_for_uri(self.dll_url)
 		f.read_async(GLib.PRIORITY_DEFAULT, None, self._cb_open_archive,
@@ -260,7 +260,7 @@ class StDownloader(GObject.GObject):
 			# Get response from async call
 			response = stream.read_bytes_finish(result)
 			if response == None:
-				raise Exception("No data recieved")
+				raise Exception("No data received")
 			# 0b of data read indicates end of file
 			if response.get_size() > 0:
 				# Not EOF. Write buffer to disk and download some more
@@ -275,13 +275,13 @@ class StDownloader(GObject.GObject):
 				self.emit("download-finished")
 				stream.close(None)
 				tmpfile.close()
-				GLib.idle_add(self._open_achive, tmpfile.name)
+				GLib.idle_add(self._open_archive, tmpfile.name)
 		except Exception as e:
 			log.exception(e)
 			self.emit("error", e, _("Download failed."))
 			return
 
-	def _open_achive(self, archive_name):
+	def _open_archive(self, archive_name):
 		try:
 			# Determine archive format
 			archive = None

--- a/syncthing_gtk/stdownloader.py
+++ b/syncthing_gtk/stdownloader.py
@@ -23,7 +23,7 @@ class StDownloader(GObject.GObject):
 
 	"""
 	Downloads, extracts and saves syncthing daemon to given location.
-	
+
 	# Create instance
 	sd = StDownloader("/tmp/syncthing.x86", "linux-386")
 	# Connect to singals
@@ -32,10 +32,10 @@ class StDownloader(GObject.GObject):
 	...
 	# Determine version
 	sd.get_version()
-	
-	# (somewhere in 'version' signal callback) 
+
+	# (somewhere in 'version' signal callback)
 	sd.download()
-	
+
 	Signals:
 		version(version)
 			emitted after current syncthing version is determined.
@@ -54,7 +54,7 @@ class StDownloader(GObject.GObject):
 		error(exception, message):
 			Emited on error. Either exception or message can be None
 	"""
-	
+
 	__gsignals__ = {
 			b"version"				: (GObject.SIGNAL_RUN_FIRST, None, (object,)),
 			b"download-starting"	: (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -64,10 +64,10 @@ class StDownloader(GObject.GObject):
 			b"extraction-finished"	: (GObject.SIGNAL_RUN_FIRST, None, ()),
 			b"error"				: (GObject.SIGNAL_RUN_FIRST, None, (object,object)),
 		}
-	
+
 	def __init__(self, target, platform):
 		"""
-		Target		- ~/.local/bin/syncthing or similar target location 
+		Target		- ~/.local/bin/syncthing or similar target location
 					for daemon binary
 		Platform	- linux-386, windows-adm64 or other suffix used on
 					syncthing releases page.
@@ -83,7 +83,7 @@ class StDownloader(GObject.GObject):
 		self.version = None
 		self.dll_url = None
 		self.dll_size = None
-	
+
 	@staticmethod
 	def get_target_folder(*a):
 		"""
@@ -92,7 +92,7 @@ class StDownloader(GObject.GObject):
 		That's %APPDATA%/syncthing on Windows or one of ~/bin, ~/.bin
 		or ~/.local/bin, whatever already exists. If none of folders
 		are existing on Linux, ~/.local/bin will be created.
-		
+
 		Path will contain ~ on Linux and needs to be expanded.
 		"""
 		if IS_WINDOWS:
@@ -103,7 +103,7 @@ class StDownloader(GObject.GObject):
 			if os.path.exists(os.path.expanduser(p)):
 				return p
 		return "~/.local/bin"
-	
+
 	def get_version(self):
 		"""
 		Determines latest usable version and prepares stuff needed for
@@ -114,20 +114,20 @@ class StDownloader(GObject.GObject):
 		uri = StDownloader.ST_GTK_URL
 		f = Gio.File.new_for_uri(uri)
 		f.load_contents_async(None, self._cb_read_compatibility, None)
-	
+
 	def get_target(self):
 		""" Returns download target """
 		return self.target
-	
+
 	def force_version(self, version):
 		self.latest_compat = version
 		self.forced = version
 		log.verbose("STDownloader: Forced Syncthing version: %s", self.latest_compat)
-		
+
 		uri = StDownloader.ST_URL
 		f = Gio.File.new_for_uri(uri)
 		f.load_contents_async(None, self._cb_read_latest, None)
-	
+
 	def _cb_read_compatibility(self, f, result, buffer, *a):
 		# Extract compatibility info from version tags in response
 		from syncthing_gtk.app import INTERNAL_VERSION
@@ -147,7 +147,7 @@ class StDownloader(GObject.GObject):
 				if not sha in tags_by_commit:
 					tags_by_commit[sha] = []
 				tags_by_commit[sha].append(name)
-			
+
 			# Determine last Syncthing-GTK version that is not newer
 			# than INTERNAL_VERSION and last Syncthing release supported
 			# by it
@@ -165,22 +165,22 @@ class StDownloader(GObject.GObject):
 							if compare_version(st_ver, self.latest_compat):
 								log.verbose("STDownloader: Got newer compatibile Syncthing version %s", st_ver)
 								self.latest_compat = st_ver
-			
+
 			log.verbose("STDownloader: Latest compatibile Syncthing version: %s", self.latest_compat)
-		
+
 		except Exception as e:
 			log.exception(e)
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))
 			return
-		
+
 		# After latest compatibile ST version is determined, determine
 		# latest actually existing version. This should be usualy same,
 		# but checking is better than downloading non-existant file.
 		uri = StDownloader.ST_URL
 		f = Gio.File.new_for_uri(uri)
 		f.load_contents_async(None, self._cb_read_latest, None)
-	
+
 	def _cb_read_latest(self, f, result, buffer, *a):
 		# Extract release version from response
 		from syncthing_gtk.app import MIN_ST_VERSION
@@ -222,13 +222,13 @@ class StDownloader(GObject.GObject):
 					latest_ver, self.version)
 		# Everything is done, emit version signal
 		self.emit("version", self.version)
-	
-	
+
+
 	def download(self):
 		try:
 			suffix = ".%s" % (".".join(self.dll_url.split(".")[-2:]),)
 			if suffix.endswith(".zip") :
-				suffix = ".zip"	
+				suffix = ".zip"
 			tmpfile = tempfile.NamedTemporaryFile(mode="wb",
 				prefix="syncthing-package.", suffix=suffix, delete=False)
 		except Exception as e:
@@ -239,9 +239,10 @@ class StDownloader(GObject.GObject):
 		f.read_async(GLib.PRIORITY_DEFAULT, None, self._cb_open_archive,
 				(tmpfile,))
 		self.emit("download-starting")
-	
-	
-	def _cb_open_archive(self, f, result, (tmpfile,)):
+
+
+	def _cb_open_archive(self, f, result, data):
+		(tmpfile,) = data
 		stream = None
 		try:
 			stream = f.read_finish(result)
@@ -252,8 +253,9 @@ class StDownloader(GObject.GObject):
 			return
 		stream.read_bytes_async(CHUNK_SIZE, GLib.PRIORITY_DEFAULT, None,
 				self._cb_download, (tmpfile, 0))
-	
-	def _cb_download(self, stream, result, (tmpfile, downloaded)):
+
+	def _cb_download(self, stream, result, data):
+		(tmpfile, downloaded) = data
 		try:
 			# Get response from async call
 			response = stream.read_bytes_finish(result)
@@ -278,7 +280,7 @@ class StDownloader(GObject.GObject):
 			log.exception(e)
 			self.emit("error", e, _("Download failed."))
 			return
-	
+
 	def _open_achive(self, archive_name):
 		try:
 			# Determine archive format
@@ -316,8 +318,9 @@ class StDownloader(GObject.GObject):
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))
 			return
-	
-	def _extract(self, (archive, compressed, output, extracted, ex_size)):
+
+	def _extract(self, data):
+		(archive, compressed, output, extracted, ex_size) = data
 		try:
 			buffer = compressed.read(CHUNK_SIZE)
 			read_size = len(buffer)
@@ -347,7 +350,7 @@ class StDownloader(GObject.GObject):
 				_("Failed to determine latest Syncthing version."))
 			return
 		return False
-	
+
 	@staticmethod
 	def determine_platform():
 		"""
@@ -389,21 +392,21 @@ class ZipThatPretendsToBeTar(zipfile.ZipFile):
 	""" Because ZipFile and TarFile are _almost_ the same -_- """
 	def __init__(self, filename, mode):
 		zipfile.ZipFile.__init__(self, filename, mode)
-	
+
 	def getnames(self):
 		""" Return the members as a list of their names. """
 		return self.namelist()
-		
+
 	def getmember(self, name):
 		"""
 		Return a TarInfo object for member name. If name can not be
 		found in the archive, KeyError is raised
 		"""
 		return ZipThatPretendsToBeTar.ZipInfo(self, name)
-	
+
 	def extractfile(self, name):
 		return self.open(name, "r")
-	
+
 	class ZipInfo:
 		def __init__(self, zipfile, name):
 			info = zipfile.getinfo(name)
@@ -411,7 +414,7 @@ class ZipThatPretendsToBeTar(zipfile.ZipFile):
 				if not (x.startswith("_") or x.endswith("_")):
 					setattr(self, x, getattr(info, x))
 			self.size = self.file_size
-		
+
 		def isfile(self, *a):
 			# I don't exactly expect anything but files in ZIP...
 			return True

--- a/syncthing_gtk/stdownloader.py
+++ b/syncthing_gtk/stdownloader.py
@@ -168,7 +168,7 @@ class StDownloader(GObject.GObject):
 			
 			log.verbose("STDownloader: Latest compatibile Syncthing version: %s", self.latest_compat)
 		
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))
@@ -211,7 +211,7 @@ class StDownloader(GObject.GObject):
 			del f
 			if self.dll_url is None:
 				raise Exception("No release to download")
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))
@@ -231,7 +231,7 @@ class StDownloader(GObject.GObject):
 				suffix = ".zip"	
 			tmpfile = tempfile.NamedTemporaryFile(mode="wb",
 				prefix="syncthing-package.", suffix=suffix, delete=False)
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e, _("Failed to create temporaly file."))
 			return
@@ -246,7 +246,7 @@ class StDownloader(GObject.GObject):
 		try:
 			stream = f.read_finish(result)
 			del f
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e, _("Download failed."))
 			return
@@ -274,7 +274,7 @@ class StDownloader(GObject.GObject):
 				stream.close(None)
 				tmpfile.close()
 				GLib.idle_add(self._open_achive, tmpfile.name)
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e, _("Download failed."))
 			return
@@ -311,7 +311,7 @@ class StDownloader(GObject.GObject):
 						output = file(self.target, "wb")
 						GLib.idle_add(self._extract, (archive, compressed, output, 0, tinfo.size))
 						return
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))
@@ -341,7 +341,7 @@ class StDownloader(GObject.GObject):
 				compressed.close()
 				self.emit("extraction-progress", 1.0)
 				self.emit("extraction-finished")
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			self.emit("error", e,
 				_("Failed to determine latest Syncthing version."))

--- a/syncthing_gtk/stdownloader.py
+++ b/syncthing_gtk/stdownloader.py
@@ -335,7 +335,7 @@ class StDownloader(GObject.GObject):
 				# Change file mode to 0755
 				if hasattr(os, "fchmod"):
 					# ... on Unix
-					os.fchmod(output.fileno(), 0755)
+					os.fchmod(output.fileno(), 0o755)
 				output.close()
 				archive.close()
 				compressed.close()

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -55,8 +55,8 @@ if IS_WINDOWS:
 	import wmi, _winreg
 
 """ Localization lambdas """
-_ = lambda(a): _uc(gettext.gettext(a))
-_uc = lambda(b): b if type(b) == unicode else b.decode("utf-8")
+_ = lambda a: _uc(gettext.gettext(a))
+_uc = lambda b: b if type(b) == unicode else b.decode("utf-8")
 
 def luhn_b32generate(s):
 	"""

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -91,7 +91,7 @@ def check_device_id(nid):
 			p = nid[i*14:((i+1)*14)-1]
 			try:
 				l = luhn_b32generate(p)
-			except Exception, e:
+			except Exception as e:
 				log.exception(e)
 				return False
 			g = "%s%s" % (p, l)
@@ -497,7 +497,7 @@ def set_run_on_startup(enabled, program_name, executable, icon="", description="
 			try:
 				file(desktopfile, "w").write((DESKTOP_FILE % (
 					program_name, executable, icon, description)).encode('utf-8'))
-			except Exception, e:
+			except Exception as e:
 				# IO errors or out of disk space... Not really
 				# expected, but may happen
 				log.warning("Failed to create autostart entry: %s", e)
@@ -506,7 +506,7 @@ def set_run_on_startup(enabled, program_name, executable, icon="", description="
 			try:
 				if os.path.exists(desktopfile):
 					os.unlink(desktopfile)
-			except Exception, e:
+			except Exception as e:
 				# IO or access error
 				log.warning("Failed to remove autostart entry: %s", e)
 				return False
@@ -534,7 +534,7 @@ def can_upgrade_binary(binary_path):
 				os.unlink(path)
 			# return Maybe
 			return True
-		except Exception, e:
+		except Exception as e:
 			log.exception(e)
 			return False
 	else:

--- a/syncthing_gtk/uisettingsdialog.py
+++ b/syncthing_gtk/uisettingsdialog.py
@@ -211,7 +211,7 @@ class UISettingsDialog(EditorDialog):
 					try:
 						# Create directory first
 						os.makedirs(os.path.dirname(target))
-					except Exception, e:
+					except Exception as e:
 						# Ignore "file already exists" error
 						pass
 					try:
@@ -219,7 +219,7 @@ class UISettingsDialog(EditorDialog):
 							os.unlink(target)
 						os.symlink(source, target)
 						log.info("Created symlink '%s' -> '%s'", source, target)
-					except Exception, e:
+					except Exception as e:
 						log.error("Failed to symlink '%s' -> '%s'", source, target)
 						log.error(e)
 			else:
@@ -230,7 +230,7 @@ class UISettingsDialog(EditorDialog):
 						try:
 							os.unlink(target)
 							log.info("Removed '%s'", target)
-						except Exception, e:
+						except Exception as e:
 							log.error("Failed to remove '%s'", target)
 							log.error(e)
 		

--- a/syncthing_gtk/wizard.py
+++ b/syncthing_gtk/wizard.py
@@ -517,7 +517,7 @@ class GenerateKeysPage(Page):
 		# Create it, if needed
 		try:
 			os.makedirs(self.parent.st_configdir)
-		except Exception, e:
+		except Exception as e:
 			self.parent.output_line("syncthing-gtk: Failed to create configuration directory")
 			self.parent.output_line("syncthing-gtk: %s" % (str(e),))
 		# Run syncthing -generate
@@ -655,7 +655,7 @@ class SaveSettingsPage(Page):
 			# Remove config.xml that I just created
 			try:
 				os.unlink(self.parent.st_configfile)
-			except Exception, e:
+			except Exception as e:
 				self.parent.output_line("syncthing-gtk: %s" % (str(e),))
 			self.parent.error(self,
 				_("Failed to find unused port for listening."),
@@ -702,7 +702,7 @@ class SaveSettingsPage(Page):
 			# Load XML file
 			config = file(self.parent.st_configfile, "r").read()
 			xml = minidom.parseString(config)
-		except Exception, e:
+		except Exception as e:
 			self.parent.output_line("syncthing-gtk: %s" % (traceback.format_exc(),))
 			self.parent.error(self,
 				_("Failed to load Syncthing configuration"),
@@ -732,7 +732,7 @@ class SaveSettingsPage(Page):
 			gui.setAttribute("enabled", "true")
 			gui.setAttribute("tls", "false")
 			au.firstChild.replaceWholeText("0")
-		except Exception, e:
+		except Exception as e:
 			self.parent.output_line("syncthing-gtk: %s" % (traceback.format_exc(),))
 			self.parent.error(self,
 				_("Failed to modify Syncthing configuration"),
@@ -742,7 +742,7 @@ class SaveSettingsPage(Page):
 		try:
 			# Write XML back to file
 			file(self.parent.st_configfile, "w").write(xml.toxml().encode("utf-8"))
-		except Exception, e:
+		except Exception as e:
 			self.parent.output_line("syncthing-gtk: %s" % (traceback.format_exc(),))
 			self.parent.error(self,
 				_("Failed to save Syncthing configuration"),


### PR DESCRIPTION
Python 3 syntax for things like Exception handling, numeric octal literals, and set literals is backported to Python 2.7, so we can use it without any problems.

Implicit tuple unpacking is not supported in Python 3, so instead we can just make the tuple unpacking explicit.