### PR TITLE
More backwards-compatible Python 3 changes

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -6,6 +6,7 @@ Main application window
 """
 
 from __future__ import unicode_literals
+import itertools
 from gi.repository import Gtk, Gio, Gdk, GLib, GdkPixbuf
 from syncthing_gtk.tools import _
 from syncthing_gtk.tools import (
@@ -1246,13 +1247,13 @@ class App(Gtk.Application, TimerManager):
 					if box in f["devices"]:
 						to_hilight.add(f)
 				to_hilight.add(box)
-		for box in [] + self.devices.values() + self.folders.values():
+		for box in itertools.chain(self.devices.values(), self.folders.values()):
 			box.set_hilight(box in to_hilight)
-	
+
 	def is_visible(self):
 		""" Returns True if main window is visible """
 		return self["window"].is_visible()
-	
+
 	def show(self):
 		"""
 		Shows main window or brings it to front, if is already visible.

--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -719,7 +719,7 @@ class App(Gtk.Application, TimerManager):
 		elif reason == Daemon.OLD_VERSION and self.config["st_autoupdate"] and not self.process is None and not StDownloader is None:
 			# Daemon is too old, but autoupdater is enabled and I have control of deamon.
 			# Try to update.
-			from configuration import LONG_AGO
+			from .configuration import LONG_AGO
 			self.config["last_updatecheck"] = LONG_AGO
 			self.restart_after_update = True
 			self.close_connect_dialog()

--- a/syncthing_gtk/daemon.py
+++ b/syncthing_gtk/daemon.py
@@ -1440,7 +1440,7 @@ class ConnectionRestarted(Exception):
 
 if __name__ == "__main__":
 	# Small thing for testing
-	from tools import init_logging, set_logging_level
+	from .tools import init_logging, set_logging_level
 	init_logging()
 	set_logging_level(True, True)
 	daemon = Daemon()

--- a/syncthing_gtk/iddialog.py
+++ b/syncthing_gtk/iddialog.py
@@ -7,7 +7,7 @@ Dialog with Device ID and generated QR code
 
 from __future__ import unicode_literals
 from gi.repository import Gio, GLib
-from tools import IS_WINDOWS
+from .tools import IS_WINDOWS
 from syncthing_gtk.uibuilder import UIBuilder
 import urllib2, httplib, ssl
 import os, tempfile, logging

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -365,7 +365,7 @@ def get_config_dir():
 		return os.environ["XDG_CONFIG_HOME"]
 	if IS_WINDOWS and not IS_XP:
 		try:
-			import windows
+			from . import windows
 			return windows.get_unicode_home()
 		except Exception:
 			pass

--- a/syncthing_gtk/uibuilder.py
+++ b/syncthing_gtk/uibuilder.py
@@ -15,7 +15,7 @@ Usage:
 from __future__ import unicode_literals
 from gi.repository import Gtk
 from xml.dom import minidom
-from tools import GETTEXT_DOMAIN, IS_WINDOWS
+from .tools import GETTEXT_DOMAIN, IS_WINDOWS
 from syncthing_gtk.tools import get_locale_dir
 from syncthing_gtk.tools import _ # gettext function
 import logging


### PR DESCRIPTION
These are very slightly more invasive than the previous set (but not enormously so), and as such deserve a bit more scrutiny.

But FWIW, I did a little testing on my machine and everything worked fine.

* Made all relative imports explicit
* In places where ```dict.keys()``` and ```dict.values()``` are used with list operations, wrap them with ```list()``` first
    * In Python 3, ```dict.keys()``` and ```dict.values()``` behave just like ```xrange()```, or ```dict.iterkeys()```/```dict.itervalues()```.  Therefore, while iterating over them is exactly the same, if you want to do list operations with them, you have to convert them into lists first.
* Changed ```xrange()``` to ```range()```
    * For small range sizes, the difference should be imperceptible

More detail in commit messages / comments.
