### PR TITLE
Specify integer division explicitly

### DIFF
--- a/syncthing_gtk/infobox.py
+++ b/syncthing_gtk/infobox.py
@@ -373,7 +373,7 @@ class InfoBox(Gtk.Container):
 		"""
 		hx = hx.lstrip('#')
 		l = len(hx)
-		color = [ float(int(hx[i:i+l/3], 16)) / 255.0 for i in range(0, l, l/3) ]
+		color = [ float(int(hx[i:i+l//3], 16)) / 255.0 for i in range(0, l, l//3) ]
 		while len(color) < 4:
 			color.append(1.0)
 		return color

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -71,7 +71,7 @@ def luhn_b32generate(s):
 			raise ValueError("Digit %s is not valid" % (c,))
 		addend = factor * codepoint
 		factor = 1 if factor == 2 else 2
-		addend = (addend / n) + (addend % n)
+		addend = (addend // n) + (addend % n)
 		sum += addend
 	remainder = sum % n
 	checkcodepoint = (n - remainder) % n


### PR DESCRIPTION
Python 2's division operator behaves differently depending on the type
of the operands. If both operands are integer types, it will perform an
'integer division', whereas if one or both operands are a floating point
type it will perform a 'true division'.

e.g. In Python 2:

    5 / 2 == 2
    5 / 2.0 == 2.5

In Python 3, the division operator always performs a 'true division',
and the result will always be a floating point type regardless of the
input types.

e.g. In Python 3:

    5 / 2 == 2.5
    5 / 2.0 == 2.5

Both Python 2 and Python 3 allow the // operator, which always performs
floor (integer) division.

e.g. For both Python 2 and Python 3:

    5 // 2 == 2
    5 // 2.0 == 2.0

In places where both the operands are/should be integers, let's use // instead
of /. In Python 2, it will behave the same for these operations as /, but is
more explicit.

When changing this it appeared that for the majority of division operations, you had already made at least one operand a float in order to get the "true division" behavior. So there were very few places where this needed to be changed.