### PR TITLE
Use print_function from future

### DIFF
--- a/build_windows.py
+++ b/build_windows.py
@@ -4,6 +4,7 @@ Do './build_windows.py build' to build exe, then call
 'makensis syncthing-gtk.nsis' to create instalation package.
 """
 
+from __future__ import print_function
 import os, site, sys, shutil, re
 from cx_Freeze import setup, Executable
 from cx_Freeze.freezer import Freezer, VersionInfo
@@ -137,11 +138,11 @@ setup(
 )
 
 if 'build' in sys.argv:
-	for l in wrong_sized_dll:
-		print "replacing", l
+	for lib in wrong_sized_dll:
+		print("Replacing {}".format(lib))
 		shutil.copy(
-			os.path.join(gnome_dll_path, l),
-			os.path.join(build_dir, l)
+			os.path.join(gnome_dll_path, lib),
+			os.path.join(build_dir, lib)
 		)
 	# Copy some theme icons
 	sizes = ["16x16", "24x24", "32x32", "scalable"]
@@ -195,25 +196,25 @@ if 'build' in sys.argv:
 					os.makedirs(os.path.join(target_path, theme, size, cat))
 				except Exception : pass
 				for icon in icons[cat]:
-					print "Copying icon %s/%s/%s/%s" % (theme, size, cat, icon)
+					print("Copying icon %s/%s/%s/%s" % (theme, size, cat, icon))
 					icon = "%s.%s" % (icon, extension)
 					src = os.path.join(src_path, theme, size, cat, icon)
 					dst = os.path.join(target_path, theme, size, cat, icon)
 					if os.path.exists(src):
 						shutil.copy(src, dst)
-		print "Copying theme index for", theme
+		print("Copying theme index for", theme)
 		shutil.copy(
 			os.path.join(src_path, theme, "index.theme"),
 			os.path.join(target_path, theme, "index.theme")
 		)
-	
-	print "Copying even more icons"
+
+	print("Copying even more icons")
 	shutil.copy(
 		os.path.join(build_dir, "icons/128x128/apps/syncthing-gtk.png"),
 		os.path.join(build_dir, "icons/syncthing-gtk.png")
 	)
-	
-	print "Copying glib schemas"
+
+	print("Copying glib schemas")
 	if not os.path.exists(os.path.join(build_dir, "/share/glib-2.0/schemas")):
 		target_path = os.path.join(build_dir, "share/glib-2.0/schemas")
 		src_path = os.path.join(gnome_dll_path, "share/glib-2.0/schemas")
@@ -223,9 +224,9 @@ if 'build' in sys.argv:
 			src = os.path.join(src_path, filename)
 			target = os.path.join(target_path, filename)
 			shutil.copy(src, target)
-	
-	
-	print "Fixing https://github.com/syncthing/syncthing-gtk/issues/313"
+
+
+	print("Fixing https://github.com/syncthing/syncthing-gtk/issues/313")
 	# Needs http://win-builds.org/1.5.0/packages/windows_32/FILENAME in in work directory
 	FILENAME = "glib-networking-2.36.2-1-i686-w64-mingw32.txz"
 	tmpdir = mkdtemp()
@@ -238,10 +239,10 @@ if 'build' in sys.argv:
 	archive.close()
 	os.chdir(cwd)
 	if tarxz.returncode != 0:
-		print >>sys.stderr, "Failed to unpack", FILENAME
+		print("Failed to unpack archive '{}'".format(FILENAME), file=sys.stderr)
 		sys.exit(1)
 	
-	print "Storing version"
+	print("Storing version")
 	with open(os.path.join(build_dir, "__version__"), "w") as f:
 		f.write(get_version())
 	with open(os.path.join(build_dir, "..", "version.nsh"), "w") as f:

--- a/scripts/syncthing-gtk-exe.py
+++ b/scripts/syncthing-gtk-exe.py
@@ -1,5 +1,6 @@
 #!/c/Python27/python.exe
 # Note: this one is used by Windows
+from __future__ import print_function
 import sys, os, _winreg
 
 if __name__ == "__main__":
@@ -15,7 +16,7 @@ if __name__ == "__main__":
 		data_path = os.path.join(os.getcwd(), "data")
 		config_dir = os.path.join(data_path, "syncthing-gtk")
 		if not os.path.exists(config_dir):
-			print "creating", config_dir
+			print("Creating directory '{}'".format(config_dir))
 			os.makedirs(config_dir)
 		os.environ["LOCALAPPDATA"] = data_path
 		os.environ["APPDATA"] = data_path

--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -5,7 +5,7 @@ Syncthing-GTK - App
 Main application window
 """
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 import itertools
 from gi.repository import Gtk, Gio, Gdk, GLib, GdkPixbuf
 from syncthing_gtk.tools import _
@@ -199,16 +199,16 @@ class App(Gtk.Application, TimerManager):
 		else:
 			# Fallback for old GTK without option parsing
 			if "-h" in sys.argv or "--help" in sys.argv:
-				print "Usage:"
-				print "  %s [arguments]" % (sys.argv[0],)
-				print "Arguments:"
+				print("Usage:")
+				print("  %s [arguments]" % (sys.argv[0],))
+				print("Arguments:")
 				for o in self.arguments:
 					# Don't display hidden and unsupported parameters
 					if not o.long_name in ("force-update", "quit"):
-						print "  -%s, --%s %s" % (
+						print("  -%s, --%s %s" % (
 							chr(o.short_name),
 							o.long_name.ljust(10),
-							o.description)
+							o.description))
 				sys.exit(0)
 			def is_option(name):
 				# Emulating Gtk.Application.do_local_options
@@ -2087,9 +2087,9 @@ class App(Gtk.Application, TimerManager):
 	
 	
 	def cb_daemon_line_captured(self, daemon, line):
-		print line
-	
-	
+		print(line)
+
+
 	def cb_daemon_exit(self, proc, error_code):
 		if proc == self.process:
 			# Whatever happens, if daemon dies while it shouldn't,

--- a/syncthing_gtk/daemon.py
+++ b/syncthing_gtk/daemon.py
@@ -8,7 +8,7 @@ Create instance, connect singal handlers and call daemon.reconnect()
 
 """
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 from gi.repository import Gio, GLib, GObject
 from syncthing_gtk.timermanager import TimerManager
 from syncthing_gtk.tools import parsetime, get_header, compare_version
@@ -1117,7 +1117,7 @@ class RESTRequest(Gio.SocketClient):
 			if response == None:
 				raise Exception("No data recieved")
 		except Exception as e:
-			print e
+			print(e)
 			self._connection.close(None)
 			self._error(e)
 			return
@@ -1353,7 +1353,7 @@ class EventPollLoop(RESTRequest):
 		try:
 			self._connection.get_output_stream().write_all(get_str, None)
 		except Exception as e:
-			print e
+			print(e)
 			self._connection.close(None)
 			return self.start()
 		self._connection.get_input_stream().read_bytes_async(10, 1, None, self._chunk)

--- a/syncthing_gtk/foldereditor.py
+++ b/syncthing_gtk/foldereditor.py
@@ -5,7 +5,7 @@ Syncthing-GTK - FolderEditorDialog
 Universal dialog handler for all Syncthing settings and editing
 """
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 from gi.repository import Gtk
 from syncthing_gtk.tools import _ # gettext function
 from syncthing_gtk.tools import generate_folder_id
@@ -192,7 +192,7 @@ class FolderEditorDialog(EditorDialog):
 	#@Overrides
 	def on_save_reuqested(self):
 		self.store_values(VALUES)
-		print self.values
+		print(self.values)
 		if self.is_new:
 			# Add new dict to configuration (edited dict is already there)
 			self.config["folders"].append(self.values)
@@ -269,9 +269,9 @@ class FolderEditorDialog(EditorDialog):
 			# fswatch disabled, return rescan interval back
 			if interval > 300:
 				vrescanIntervalS.set_value(interval / 60)
-				
-		# print self.get_value("vfsWatcherEnabled"),  cb.get_value()
-	
+
+		# print(self.get_value("vfsWatcherEnabled"),  cb.get_value())
+
 	def mark_device(self, nid):
 		""" Marks (checks) checkbox for specified device """
 		if "vdevices" in self:	# ... only if there are checkboxes here


### PR DESCRIPTION
In Python 3, 'print' was changed from a keyword into a builtin function. We can use this function from Python 2 if we import it from \_\_future\_\_.