### PR TITLE
 Replace usages of the file() builtin with open() 

### DIFF
--- a/build_windows.py
+++ b/build_windows.py
@@ -242,5 +242,7 @@ if 'build' in sys.argv:
 		sys.exit(1)
 	
 	print "Storing version"
-	file(os.path.join(build_dir, "__version__"), "w").write(get_version())
-	file(os.path.join(build_dir, "..", "version.nsh"), "w").write('!define VERSION "%s"' % (get_version(),))
+	with open(os.path.join(build_dir, "__version__"), "w") as f:
+		f.write(get_version())
+	with open(os.path.join(build_dir, "..", "version.nsh"), "w") as f:
+		f.write('!define VERSION "{version}"'.format(version=get_version()))

--- a/syncthing_gtk/aboutdialog.py
+++ b/syncthing_gtk/aboutdialog.py
@@ -42,8 +42,8 @@ class AboutDialog(object):
 			if IS_WINDOWS:
 				# pkg_resources will not work on cx_Frozen package
 				from syncthing_gtk.tools import get_install_path
-				vfile = file(os.path.join(get_install_path(), "__version__"), "r")
-				app_ver = vfile.read().strip(" \t\r\n")
+				with open(os.path.join(get_install_path(), "__version__"), "r") as vfile:
+					app_ver = vfile.read().strip(" \t\r\n")
 			else:
 				import pkg_resources, syncthing_gtk
 				if syncthing_gtk.__file__.startswith(pkg_resources.require("syncthing-gtk")[0].location):

--- a/syncthing_gtk/configuration.py
+++ b/syncthing_gtk/configuration.py
@@ -85,8 +85,9 @@ class _Configuration(object):
 				log.exception(e)
 				sys.exit(1)
 		# Load json
-		self.values = json.loads(file(self.get_config_file(), "r").read())
-	
+		with open(self.get_config_file(), "r") as conf:
+			self.values = json.loads(conf.read())
+
 	def get_default_value(self, key):
 		if IS_WINDOWS:
 			return self.WINDOWS_OVERRIDE.get(key, self.REQUIRED_KEYS[key])[-1]
@@ -162,11 +163,17 @@ class _Configuration(object):
 	
 	def save(self):
 		""" Saves configuration file """
-		file(self.get_config_file(), "w").write(json.dumps(
-			self.values, sort_keys=True, indent=4,
-			separators=(',', ': '), default=serializer
-			))
-	
+		with open(self.get_config_file(), "w") as conf:
+			conf.write(
+				json.dumps(
+					self.values,
+					sort_keys=True,
+					indent=4,
+					separators=(',', ': '),
+					default=serializer
+				)
+			)
+
 	def __iter__(self):
 		for k in self.values:
 			yield k

--- a/syncthing_gtk/daemon.py
+++ b/syncthing_gtk/daemon.py
@@ -331,7 +331,8 @@ class Daemon(GObject.GObject, TimerManager):
 			self._configxml = os.path.expanduser("~/snap/syncthing/common/syncthing/config.xml")
 		try:
 			log.debug("Reading syncthing config %s", self._configxml)
-			config = file(self._configxml, "r").read()
+			with open(self._configxml, "r") as f:
+				config = f.read()
 		except Exception as e:
 			raise InvalidConfigurationException("Failed to read daemon configuration: %s" % e)
 		try:

--- a/syncthing_gtk/infobox.py
+++ b/syncthing_gtk/infobox.py
@@ -469,7 +469,8 @@ class InfoBox(Gtk.Container):
 			if not key in svg_cache:
 				if not self.dark_color is None:
 					# Recolor svg for dark theme
-					svg_source = file(os.path.join(self.app.iconpath, icon), "r").read()
+					with open(os.path.join(self.app.iconpath, icon), "r") as f:
+						svg_source = f.read()
 					svg_source = svg_source.replace('fill:rgb(0%,0%,0%)', 'fill:rgb(100%,100%,100%)')
 					svg = Rsvg.Handle.new_from_data(svg_source.encode("utf-8"))
 				else:

--- a/syncthing_gtk/stdownloader.py
+++ b/syncthing_gtk/stdownloader.py
@@ -310,7 +310,7 @@ class StDownloader(GObject.GObject):
 						try:
 							os.makedirs(os.path.split(self.target)[0])
 						except Exception: pass
-						output = file(self.target, "wb")
+						output = open(self.target, "wb")
 						GLib.idle_add(self._extract, (archive, compressed, output, 0, tinfo.size))
 						return
 		except Exception as e:

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -449,17 +449,18 @@ def is_ran_on_startup(program_name):
 		# Check if desktop file is not marked as hidden
 		# (stupid way, but should work)
 		is_entry = False
-		for line in file(desktopfile, "r").readlines():
-			line = line.strip(" \r\t\n").lower()
-			if line == "[desktop entry]":
-				is_entry = True
-				continue
-			if "=" in line:
-				key, value = line.split("=", 1)
-				if key.strip(" ") == "hidden":
-					if value.strip(" ") == "true":
-						# Desktop file is 'hidden', i.e. disabled
-						return False
+		with open(desktopfile, "r") as f:
+			for line in f.readlines():
+				line = line.strip(" \r\t\n").lower()
+				if line == "[desktop entry]":
+					is_entry = True
+					continue
+				if "=" in line:
+					key, value = line.split("=", 1)
+					if key.strip(" ") == "hidden":
+						if value.strip(" ") == "true":
+							# Desktop file is 'hidden', i.e. disabled
+							return False
 		# File is present and not hidden - autostart is enabled
 		return is_entry
 
@@ -495,8 +496,9 @@ def set_run_on_startup(enabled, program_name, executable, icon="", description="
 				# Already exists
 				pass
 			try:
-				file(desktopfile, "w").write((DESKTOP_FILE % (
-					program_name, executable, icon, description)).encode('utf-8'))
+				with open(desktopfile, "w") as f:
+					desktop_contents = DESKTOP_FILE % (program_name, executable, icon, description)
+					f.write(desktop_contents.encode('utf-8'))
 			except Exception as e:
 				# IO errors or out of disk space... Not really
 				# expected, but may happen
@@ -526,10 +528,10 @@ def can_upgrade_binary(binary_path):
 		try:
 			path = binary_path + ".new"
 			if os.path.exists(path):
-				f = file(path, "r+b")
+				f = open(path, "r+b")
 				f.close()
 			else:
-				f = file(path, "wb")
+				f = open(path, "wb")
 				f.close()
 				os.unlink(path)
 			# return Maybe

--- a/syncthing_gtk/uibuilder.py
+++ b/syncthing_gtk/uibuilder.py
@@ -37,8 +37,9 @@ class UIBuilder(Gtk.Builder):
 			# Gtk.Builder directly
 			Gtk.Builder.add_from_file(self, filename)
 		else:
-			self.add_from_string(file(filename, "r").read())
-	
+			with open(filename, "r") as f:
+				self.add_from_string(f.read())
+
 	def add_from_string(self, string):
 		""" Builds UI from string """
 		self.xml = minidom.parseString(string)

--- a/syncthing_gtk/wizard.py
+++ b/syncthing_gtk/wizard.py
@@ -700,7 +700,8 @@ class SaveSettingsPage(Page):
 		xml = None
 		try:
 			# Load XML file
-			config = file(self.parent.st_configfile, "r").read()
+			with open(self.parent.st_configfile, "r") as conf_file:
+				config = conf_file.read()
 			xml = minidom.parseString(config)
 		except Exception as e:
 			self.parent.output_line("syncthing-gtk: %s" % (traceback.format_exc(),))
@@ -741,7 +742,8 @@ class SaveSettingsPage(Page):
 			return False
 		try:
 			# Write XML back to file
-			file(self.parent.st_configfile, "w").write(xml.toxml().encode("utf-8"))
+			with open(self.parent.st_configfile, "w") as f:
+				f.write(xml.toxml().encode("utf-8"))
 		except Exception as e:
 			self.parent.output_line("syncthing-gtk: %s" % (traceback.format_exc(),))
 			self.parent.error(self,


### PR DESCRIPTION
Python 2 documentation recommends against the usage of ```file()```, and Python 3 removes it entirely. ```open()``` can do everything ```file()``` can do and using it is identical apart from having a few extra features.

Also, it's usually recommended to use the context manager pattern when dealing with files to prevent resource leaks. If you don't close the files, they will stick around in the process' file descriptor table. When using a context manager, the file is closed at the end of the scope.Alternatively the files could just be closed manually but this is easier and cleaner.