### PR TITLE
Fix: Folder names containing unencoded html entities are blank

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1406,6 +1406,7 @@ class App(Gtk.Application, TimerManager):
 			title = display_path
 		if label not in (None, ""):
 			title = label
+		title = title.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#39;')
 		if id in self.folders:
 			# Reuse existing box
 			box = self.folders[id]


### PR DESCRIPTION
Fixing https://github.com/syncthing/syncthing-gtk/issues/525