### PR TITLE
[TASK] Improve html entity encoding

### DIFF
--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -1406,7 +1406,6 @@ class App(Gtk.Application, TimerManager):
 			title = display_path
 		if label not in (None, ""):
 			title = label
-		title = title.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#39;')
 		if id in self.folders:
 			# Reuse existing box
 			box = self.folders[id]

--- a/syncthing_gtk/infobox.py
+++ b/syncthing_gtk/infobox.py
@@ -7,7 +7,7 @@ Colorful, expandable widget displaying folder/device data
 from __future__ import unicode_literals
 from gi.repository import Gtk, Gdk, GLib, GObject, Pango, Rsvg
 from syncthing_gtk.ribar import RevealerClass
-from syncthing_gtk.tools import _ # gettext function
+from syncthing_gtk.tools import _, escape_html_entities # _ is gettext function
 import os, logging, math
 log = logging.getLogger("InfoBox")
 
@@ -313,6 +313,7 @@ class InfoBox(Gtk.Container):
 	
 	### Methods
 	def set_title(self, t):
+		t = escape_html_entities(t)
 		self.str_title = t
 		inverted = self.header_inverted and self.dark_color is None
 		col = "black" if inverted else "white"

--- a/syncthing_gtk/tools.py
+++ b/syncthing_gtk/tools.py
@@ -558,3 +558,6 @@ def generate_folder_id():
 		("".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(5)))
 		for _ in range(2)
 	))
+
+def escape_html_entities(string):
+	return string.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#39;')


### PR DESCRIPTION
This makes it more robust and properly implemented :)

Because I still got errors in the log even though it was not visible in the GUI.
```
Okt 29 23:39:41 ubuntu syncthing-gtk[3538]: Failed to set text '<span color="white" font_weight="bold" font_size="large">Memories/Persons & Pets</span>' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity - escape ampersand as &amp;
```