### PR TITLE
added translation for "receive only" folder

### DIFF
--- a/locale/de/LC_MESSAGES/syncthing-gtk.po
+++ b/locale/de/LC_MESSAGES/syncthing-gtk.po
@@ -402,6 +402,10 @@ msgstr "Alle Daten"
 msgid "Off"
 msgstr "Aus"
 
+#: syncthing_gtk/app.py:1452
+msgid "Receive Only"
+msgstr "Nur Empfangen"
+
 #: syncthing_gtk/app.py:1375
 msgid "Send Only"
 msgstr "Nur senden"


### PR DESCRIPTION
The translation for "Receive only" was missing and resulted in the English string being used on the German UI. Added the translation.