### PR TITLE
setup.py: make version comply with PEP-440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@ def get_version():
 	"""
 	try:
 		p = Popen(['git', 'describe', '--tags', '--match', 'v*'], stdout=PIPE)
-		version = p.communicate()[0].strip("\n\r \t")
+		version = p.communicate()[0].decode("ascii").strip("\n\r \t")
 		if p.returncode != 0:
 			raise Exception("git-describe failed")
+		version = version.split("-")[0].lstrip("v")  # Comply with PEP-440
 		return version
 	except: pass
 	# Git-describe method failed, try to guess from working directory name
@@ -30,6 +31,7 @@ def get_version():
 				version = "v%s" % (version,)
 			break
 		path = path[0:-1]
+	version = version.split("+")[0].lstrip("v")  # Comply with PEP-440
 	return version
 
 class BuildPyEx(build_py):


### PR DESCRIPTION
Generating Python package version from git description makes a sensible string, but it does not comply with PEP-440. Starting from version 66, setuptools are very strict, and refuse to return result to _any_ python package, if at least one _unrelated_ package installed in the system has version that is not compliant with PEP-440.

Because the version of syncthing-gtk is not PEP-440 compliant, when it is installed from a .deb package (as opposed to in a venv/snap), system-wide `aptdaemon` crashes, and GUI upgrader cannot install any updates on the system at all:

   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1044, in __init__
     self.scan(search_path)
   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1077, in scan
     self.add(dist)
   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1096, in add
     dists.sort(key=operator.attrgetter('hashcmp'), reverse=True)
   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2631, in hashcmp
     self.parsed_version,
     ^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2679, in parsed_version
     self._parsed_version = parse_version(self.version)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/pkg_resources/_vendor/packaging/version.py", line 266, in __init__
     raise InvalidVersion(f"Invalid version: '{version}'")
 pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: 'v0.9.4.4-ds-git20221205-12a9702d29ab'
 (package: syncthing-gtk)

This change brings the version as used for Python package to compliance with PEP-440. This fixes apdaemon crash, and the distro can be upgraded again.